### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/common/file_utils.py
+++ b/common/file_utils.py
@@ -118,7 +118,9 @@ def get_file(fname, origin, unpack=False,
     '''
 
     if download:
-        if 'modac.cancer.gov' in origin:
+        from urllib.parse import urlparse
+        parsed_url = urlparse(origin)
+        if parsed_url.hostname and parsed_url.hostname.endswith(".modac.cancer.gov"):
             get_file_from_modac(fpath, origin)
         else:
             print('Downloading data from', origin)


### PR DESCRIPTION
Potential fix for [https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Unified-Drug-Response-Predictor-Multi-tasking/security/code-scanning/1](https://github.com/CBIIT/NCI-DOE-Collab-Pilot1-Unified-Drug-Response-Predictor-Multi-tasking/security/code-scanning/1)

To fix the issue, we should parse the `origin` URL using `urllib.parse` to extract its hostname and then perform a proper domain check. Specifically, we should ensure that the hostname ends with `.modac.cancer.gov` to allow subdomains while preventing malicious URLs that embed the domain as a substring in unintended locations.

Steps to fix:
1. Import `urlparse` from `urllib.parse` if not already imported.
2. Parse the `origin` URL to extract its hostname.
3. Check if the hostname ends with `.modac.cancer.gov` (with a preceding dot to avoid partial matches like `evilmodac.cancer.gov`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
